### PR TITLE
Alter pca tmpdir

### DIFF
--- a/fn4_pca.py
+++ b/fn4_pca.py
@@ -283,7 +283,6 @@ pipenv run python3 pca/fn4_pca.py demos/covid/covid_config_v3.json --outputdir /
         PERSIST=PERSIST,
         disable_insertion=True,
     )
-
     
     if args.only_produce_tree_output is False:
         logger.info("Loading cog-uk metadata")


### PR DESCRIPTION
Allows flexibility in where tree output files go during fn4_pca.py execution