### PR TITLE
enable local store maintenance

### DIFF
--- a/findNeighbour4_lsmanager.py
+++ b/findNeighbour4_lsmanager.py
@@ -166,10 +166,12 @@ if __name__ == "__main__":
         
         # read benchmark
         #logging.info("Read benchmark")
-        res = localstore.read_benchmark()
-        print(res)
-        exit()
-        # create catwalk connection
+        #res = localstore.read_benchmark()
+        #print(res)
+        #exit()
+
+        # create database and catwalk connections and update the localstore using them
+        logging.info("Updating localstore with any new samples")
         hc = cw_seqComparer(
             reference=CONFIG["reference"],
             maxNs=CONFIG["MAXN_STORAGE"],
@@ -187,4 +189,5 @@ if __name__ == "__main__":
             logger.info("Exiting as run_once_only specified")
             exit(0)
 
+        logging.info("Update complete.  Rechecking in 1 hour.")
         time.sleep(3600)  # rerun in 1 hour

--- a/fn4_startup.sh
+++ b/fn4_startup.sh
@@ -137,7 +137,7 @@ nohup pipenv run python3 findNeighbour4_clustering.py $1 > $CLUSTLOG &
 sleep 0.5
 
 echo "Starting localstore manager"
-nohup pipenv run python3 findNeighbour4_lsmanager.py --path_to_config_file $1 --max_run_time 150 > $MANLOG &
+nohup pipenv run python3 findNeighbour4_lsmanager.py --path_to_config_file $1  > $MANLOG &
 
 echo "Startup complete.  Output files containing STDOUT and STDERR output are being written to $LOGDIR."
 echo "Server processes making their own log in the database. Nohup output is going to the following locations:"


### PR DESCRIPTION
Enables the generation of localstore (tar file) containing reference compressed sequence data.  This speeds up restarting when large numbers of samples are present; with SARS-CoV-2, restarting a server takes about 1h with 2M samples.